### PR TITLE
feat: add GitHub Pages deployment workflow (PR #2)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate health + manifest
+        run: |
+          echo "<html><body><h1>02luka Health OK</h1></body></html>" > _health.html
+          echo '{"status":"ok","timestamp":"'$(date -u +%FT%TZ)'"}' > manifest.json
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -112,3 +112,16 @@ Then you can command Codex:
 4. Test file upload functionality over HTTPS
 
 **Repository Ready for Codex!** 🎯
+---
+
+## 🌐 GitHub Pages Deployment (PR #2)
+
+After merging PR #2, GitHub Pages is auto-enabled.
+
+Endpoints:
+- Health check → https://ic1558.github.io/02luka/_health.html
+- Manifest → https://ic1558.github.io/02luka/manifest.json
+
+Every push to `main` will:
+- Auto-generate `_health.html` and `manifest.json`
+- Deploy latest code to GitHub Pages


### PR DESCRIPTION
## Summary
- เพิ่ม GitHub Actions workflow สำหรับ deploy ไปที่ GitHub Pages
- ทุกครั้งที่ push ไปที่ `main` จะ auto-generate `_health.html` และ `manifest.json`
- Deploy หน้าเว็บและไฟล์ทั้งหมดขึ้น GitHub Pages

## Changes
- เพิ่ม `.github/workflows/pages.yml`
- อัปเดต `DEPLOY.md` เพิ่ม section การ deploy บน GitHub Pages

## Result
หลัง merge:
- Health check URL → https://ic1558.github.io/02luka/_health.html
- Manifest URL → https://ic1558.github.io/02luka/manifest.json
- Luka app ใช้งานได้ที่ GitHub Pages