### PR TITLE
chore/ui send helper2

### DIFF
--- a/index.html
+++ b/index.html
@@ -1005,6 +1005,115 @@ function nluExtract(text){
   syncState();
 })();
   </script>
+  <script id="luka-ui-send-helper2">
+(function(){
+  const TAG = "[Luka-UI]";
+  function log(){ try{ console.log(TAG, ...arguments); }catch(_){} }
+
+  const selectors = {
+    input: [
+      "main textarea",
+      "textarea",
+      "main input[type=text]",
+      "input[type=text]",
+      "input[role=textbox]",
+      "[contenteditable=true]"
+    ],
+    send: [
+      "main button[type=submit]",
+      "button[type=submit]",
+      "main button[data-role=send-btn]",
+      "button[data-role=send-btn]",
+      "button[aria-label=Send]",
+      "button[title=Send]",
+      "form button:not([disabled])"
+    ]
+  };
+
+  function qSel(list){
+    for (const sel of list){
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function setup(){
+    const input  = qSel(selectors.input);
+    const sendBtn= qSel(selectors.send);
+
+    if (!input || !sendBtn){
+      log("waiting… input:", !!input, "send:", !!sendBtn);
+      return false;
+    }
+
+    log("hooked input:", input.tagName, "send:", sendBtn.tagName);
+
+    function hasText(){
+      if ("value" in input) return (input.value||"").trim().length>0;
+      if (input.isContentEditable) return (input.textContent||"").trim().length>0;
+      return false;
+    }
+
+    function syncState(){
+      const enable = hasText();
+      sendBtn.disabled = !enable;
+      sendBtn.setAttribute("aria-disabled", String(!enable));
+    }
+
+    // Keep state in sync
+    (["input","change","keyup"]).forEach(ev => input.addEventListener(ev, syncState));
+    // Enter to send (newline with Shift+Enter)
+    input.addEventListener("keydown", e=>{
+      if (e.key === "Enter" && !e.shiftKey){
+        if (hasText()){
+          // do NOT stop propagation unless we are sending
+          e.preventDefault();
+          sendBtn.click();
+        }
+      }
+    });
+
+    // Guard blank clicks (don’t block your existing click handler)
+    sendBtn.addEventListener("click", e=>{
+      if (!hasText()){
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        log("blocked blank send");
+      }
+    }, true); // capture so we gate prior to app handler
+
+    // Also guard form submit if any
+    const form = sendBtn.closest("form");
+    if (form){
+      form.addEventListener("submit", e=>{
+        if (!hasText()){
+          e.preventDefault();
+          log("blocked blank form submit");
+        }
+      }, true);
+    }
+
+    // Initial state
+    syncState();
+    return true;
+  }
+
+  function startWhenReady(){
+    if (setup()) return;
+    const obs = new MutationObserver(()=>{
+      if (setup()){ obs.disconnect(); }
+    });
+    obs.observe(document.documentElement, {childList:true, subtree:true});
+  }
+
+  if (document.readyState === "loading"){
+    document.addEventListener("DOMContentLoaded", startWhenReady);
+  } else {
+    startWhenReady();
+  }
+})();
+  </script>
 </body>
 <script>(()=>{const i=document.getElementById("q"),b=document.getElementById("send"),f=b&&b.closest("form");if(!i||!b)return;const s=()=>{b.disabled=!i.value.trim()};i.addEventListener("input",s);s();if(f)f.addEventListener("submit",e=>e.preventDefault())})();</script>
 </html>


### PR DESCRIPTION
- **fix(pages): update actions to latest (checkout@v4, upload-pages-artifact@v3, deploy-pages@v4) + add .nojekyll**
- **chore(pages): add 404.html for clean routing**
- **docs: add README with Pages status badge**
- **feat(nlu): browser-only NLU (compromise) + intent/entities + send() wiring + UI hint**
- **ui: enable Send when input has text; prevent blank submits**
- **ui: enable Send + Enter; prevent blank submits (inject helper script)**
- **ui: robust Send helper (observer, diagnostics, blank-guard)**
