### PR TITLE
Scaffold Boss Workspace API and UI

### DIFF
--- a/boss-api/package-lock.json
+++ b/boss-api/package-lock.json
@@ -8,6 +8,7 @@
       "name": "boss-api",
       "version": "0.1.0",
       "dependencies": {
+        "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2"
       }
@@ -128,6 +129,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -532,6 +546,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/boss-api/package.json
+++ b/boss-api/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
   }
 }

--- a/boss-api/src/index.js
+++ b/boss-api/src/index.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import dotenv from 'dotenv';
+import cors from 'cors';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import path from 'node:path';
@@ -17,6 +18,17 @@ const defaultSotPath = path.resolve(__dirname, '..', '..');
 const SOT_PATH = process.env.SOT_PATH || defaultSotPath;
 const pathResolverScript = path.resolve(__dirname, '..', '..', 'g', 'tools', 'path_resolver.sh');
 const execFileAsync = promisify(execFile);
+
+const configuredOrigins = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',').map((origin) => origin.trim()).filter(Boolean)
+  : [];
+const corsOrigins = configuredOrigins.length > 0 ? configuredOrigins : ['http://localhost:5173'];
+
+app.use(
+  cors({
+    origin: corsOrigins,
+  })
+);
 
 const allowedFolders = new Set([
   'inbox',

--- a/boss-ui/package-lock.json
+++ b/boss-ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "boss-ui",
       "version": "0.1.0",
       "dependencies": {
+        "dompurify": "^3.1.6",
         "marked": "^12.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1107,6 +1108,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1216,6 +1224,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/boss-ui/package.json
+++ b/boss-ui/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "marked": "^12.0.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "dompurify": "^3.1.6"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/boss-ui/src/App.jsx
+++ b/boss-ui/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 
 const API_BASE = 'http://localhost:4000';
 
@@ -66,7 +67,10 @@ export default function App() {
     }
   }
 
-  const renderedMarkdown = useMemo(() => marked.parse(content || defaultMarkdown), [content]);
+  const renderedMarkdown = useMemo(() => {
+    const parsed = marked.parse(content || defaultMarkdown);
+    return DOMPurify.sanitize(parsed);
+  }, [content]);
 
   return (
     <div className="app-shell">


### PR DESCRIPTION
## Summary
- add a Boss API service that resolves human namespace paths through the shared path resolver and exposes list/read endpoints
- scaffold a Boss Workspace React UI with sidebar navigation, file listing, and markdown preview wired to the API
- document local setup, environment configuration, and smoke tests for both layers while ignoring build artifacts and node modules

## Testing
- node src/index.js (boss-api)
- npm run build (boss-ui)


------
https://chatgpt.com/codex/tasks/task_e_68dc1db3fcdc8329b1fe55bf2475d237