### PR TITLE
Add central context backend and integrate UI

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -236,7 +236,15 @@ async function handleGetFile(req, res) {
     return res.status(404).json({ error: `Unknown folder: ${folder}` });
   }
   try {
-    const filePath = path.join(BOSS_ROOT, folder, name);
+    if (!name || name.includes('/') || name.includes('\\')) {
+      return res.status(400).json({ error: 'Invalid file name' });
+    }
+    const folderRoot = path.join(BOSS_ROOT, folder);
+    const filePath = path.join(folderRoot, name);
+    const relative = path.relative(folderRoot, filePath);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      return res.status(400).json({ error: 'Invalid file path' });
+    }
     const data = await fsp.readFile(filePath, 'utf8');
     res.type('text/plain').send(data);
   } catch (err) {


### PR DESCRIPTION
## Summary
- add an Express-based backend that maps chat traffic into the boss central-context workspace and exposes chat/folder APIs
- seed configurable gateway profiles and scaffold the boss workspace directories used by the mapper
- update the Luka UI to load gateway profiles, talk to the central-context backend, and render pending/system metadata for messages

## Testing
- npm install --prefix backend
- node backend/server.js & sleep 1; curl -s http://127.0.0.1:4123/health

------
https://chatgpt.com/codex/tasks/task_e_68dc1199c9f08329b21dd18276f5a1c6