### PR TITLE
Add boss workspace API and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ python3 -m http.server 8080
 open http://localhost:8080
 ```
 
+### Smoke Test: Boss Workspace
+```bash
+# Terminal 1 - start the API
+cd boss-api
+node server.js
+
+# Terminal 2 - serve the static UI
+cd boss-ui
+python3 -m http.server 8081
+open http://localhost:8081
+```
+
 ## 🔧 Available Scripts
 
 | Script | Purpose |

--- a/boss-api/.env.sample
+++ b/boss-api/.env.sample
@@ -1,0 +1,6 @@
+# Optional override for repository root.
+# When set, path_resolver.sh will resolve paths relative to this directory.
+SOT_PATH=
+
+# Port for the boss-api HTTP server.
+PORT=4000

--- a/boss-api/README.md
+++ b/boss-api/README.md
@@ -1,0 +1,29 @@
+# boss-api
+
+A minimal Node.js HTTP server that exposes read-only access to Boss Workspace folders.
+
+## Requirements
+
+- Node.js 18+
+
+## Setup
+
+1. (Optional) Copy `.env.sample` to `.env` and adjust values.
+2. Install dependencies (none required).
+
+## Run
+
+```bash
+node server.js
+```
+
+The server listens on `PORT` (default `4000`).
+
+## API
+
+- `GET /api/list/:folder` – List files in an allowed folder.
+- `GET /api/file/:folder/:name` – Retrieve file contents from an allowed folder.
+
+Allowed folders: `inbox`, `sent`, `deliverables`, `dropbox`, `drafts`, `documents`.
+
+All file paths are resolved via `g/tools/path_resolver.sh` using `human:<folder>` keys to respect the Single Source of Truth mapping.

--- a/boss-api/server.js
+++ b/boss-api/server.js
@@ -1,0 +1,130 @@
+const http = require('http');
+const { execFile } = require('child_process');
+const fs = require('fs').promises;
+const path = require('path');
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
+const ALLOWED_FOLDERS = new Set([
+  'inbox',
+  'sent',
+  'deliverables',
+  'dropbox',
+  'drafts',
+  'documents',
+]);
+
+const repoRoot = process.env.SOT_PATH || path.resolve(__dirname, '..');
+const resolverScript = path.join(repoRoot, 'g', 'tools', 'path_resolver.sh');
+
+function sendJson(res, statusCode, data) {
+  const payload = JSON.stringify(data);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(payload);
+}
+
+function sendText(res, statusCode, text, contentType = 'text/plain; charset=utf-8') {
+  res.writeHead(statusCode, {
+    'Content-Type': contentType,
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(text);
+}
+
+function resolveFolder(folder) {
+  return new Promise((resolve, reject) => {
+    if (!ALLOWED_FOLDERS.has(folder)) {
+      reject(new Error('Invalid folder'));
+      return;
+    }
+
+    execFile(
+      'bash',
+      [resolverScript, `human:${folder}`],
+      { cwd: repoRoot, env: process.env },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr.trim() || error.message));
+          return;
+        }
+        resolve(stdout.trim());
+      }
+    );
+  });
+}
+
+async function handleList(folder, res) {
+  try {
+    const targetDir = await resolveFolder(folder);
+    const entries = await fs.readdir(targetDir, { withFileTypes: true });
+    const files = entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .sort((a, b) => a.localeCompare(b));
+    sendJson(res, 200, { files });
+  } catch (error) {
+    sendJson(res, 400, { error: error.message });
+  }
+}
+
+async function handleFile(folder, name, res) {
+  try {
+    const targetDir = await resolveFolder(folder);
+    const targetRoot = path.resolve(targetDir);
+    const resolvedPath = path.resolve(targetRoot, name);
+    const relative = path.relative(targetRoot, resolvedPath);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('Invalid file path');
+    }
+    const content = await fs.readFile(resolvedPath, 'utf-8');
+    sendText(res, 200, content);
+  } catch (error) {
+    sendJson(res, 400, { error: error.message });
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    });
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const segments = url.pathname.split('/').filter(Boolean);
+
+  if (req.method === 'GET' && segments.length === 3 && segments[0] === 'api' && segments[1] === 'list') {
+    const folder = segments[2];
+    await handleList(folder, res);
+    return;
+  }
+
+  if (req.method === 'GET' && segments.length >= 4 && segments[0] === 'api' && segments[1] === 'file') {
+    const folder = segments[2];
+    const name = decodeURIComponent(segments.slice(3).join('/'));
+    await handleFile(folder, name, res);
+    return;
+  }
+
+  res.writeHead(404, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+server.listen(PORT, () => {
+  console.log(`boss-api listening on port ${PORT}`);
+});

--- a/boss-ui/index.html
+++ b/boss-ui/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Boss Workspace</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: Arial, sans-serif;
+        color: #1f1f1f;
+      }
+
+      .app {
+        display: grid;
+        grid-template-columns: 220px 260px 1fr;
+        height: 100vh;
+      }
+
+      .sidebar {
+        background: #f4f6fb;
+        border-right: 1px solid #dbe1f1;
+        padding: 24px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .sidebar h1 {
+        font-size: 1.2rem;
+        margin: 0 0 12px;
+      }
+
+      .folder {
+        padding: 8px 12px;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+
+      .folder.active,
+      .folder:hover {
+        background: #dbe1f1;
+      }
+
+      .file-list {
+        border-right: 1px solid #dbe1f1;
+        overflow-y: auto;
+        padding: 16px;
+        background: #fff;
+      }
+
+      .file-item {
+        padding: 8px 10px;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+
+      .file-item:hover,
+      .file-item.active {
+        background: #eef2ff;
+      }
+
+      .preview {
+        padding: 20px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        background: #fafbff;
+      }
+
+      .empty-state {
+        color: #6b7280;
+        font-style: italic;
+      }
+
+      @media (max-width: 960px) {
+        .app {
+          grid-template-columns: 180px 1fr;
+          grid-template-rows: 220px 1fr;
+        }
+
+        .file-list {
+          grid-column: 1 / span 2;
+          grid-row: 2;
+        }
+
+        .preview {
+          grid-column: 1 / span 2;
+          grid-row: 3;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <h1>Boss Workspace</h1>
+        <div id="folders"></div>
+      </aside>
+      <section class="file-list" id="file-list">
+        <p class="empty-state">Select a folder to load files.</p>
+      </section>
+      <section class="preview" id="preview">
+        <p class="empty-state">Choose a file to preview its contents.</p>
+      </section>
+    </div>
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/boss-ui/main.js
+++ b/boss-ui/main.js
@@ -1,0 +1,114 @@
+const API_BASE = 'http://localhost:4000/api';
+const folders = ['inbox', 'sent', 'deliverables', 'dropbox', 'drafts', 'documents'];
+
+const folderContainer = document.getElementById('folders');
+const fileList = document.getElementById('file-list');
+const preview = document.getElementById('preview');
+
+let currentFolder = null;
+let currentFile = null;
+
+function setActiveFolder(folder) {
+  currentFolder = folder;
+  currentFile = null;
+  document.querySelectorAll('.folder').forEach((el) => {
+    el.classList.toggle('active', el.dataset.folder === folder);
+  });
+}
+
+function setActiveFile(name) {
+  currentFile = name;
+  document.querySelectorAll('.file-item').forEach((el) => {
+    el.classList.toggle('active', el.dataset.file === name);
+  });
+}
+
+async function loadFolders() {
+  folderContainer.innerHTML = '';
+  folders.forEach((folder) => {
+    const item = document.createElement('div');
+    item.className = 'folder';
+    item.dataset.folder = folder;
+    item.textContent = folder.charAt(0).toUpperCase() + folder.slice(1);
+    item.addEventListener('click', () => {
+      if (currentFolder === folder) {
+        return;
+      }
+      setActiveFolder(folder);
+      renderFileListLoading();
+      fetchFileList(folder);
+    });
+    folderContainer.appendChild(item);
+  });
+}
+
+function renderFileListLoading() {
+  fileList.innerHTML = '<p class="empty-state">Loading files…</p>';
+  preview.innerHTML = '<p class="empty-state">Choose a file to preview its contents.</p>';
+}
+
+function renderFileList(files) {
+  if (!files.length) {
+    fileList.innerHTML = '<p class="empty-state">No files found in this folder.</p>';
+    return;
+  }
+
+  const list = document.createElement('div');
+  files.forEach((fileName) => {
+    const item = document.createElement('div');
+    item.className = 'file-item';
+    item.dataset.file = fileName;
+    item.textContent = fileName;
+    item.addEventListener('click', () => {
+      if (currentFile === fileName) {
+        return;
+      }
+      setActiveFile(fileName);
+      preview.innerHTML = '<p class="empty-state">Loading preview…</p>';
+      fetchFileContent(currentFolder, fileName);
+    });
+    list.appendChild(item);
+  });
+  fileList.innerHTML = '';
+  fileList.appendChild(list);
+}
+
+function renderPreview(content) {
+  const pre = document.createElement('pre');
+  pre.textContent = content;
+  preview.innerHTML = '';
+  preview.appendChild(pre);
+}
+
+function renderError(target, message) {
+  target.innerHTML = `<p class="empty-state">${message}</p>`;
+}
+
+async function fetchFileList(folder) {
+  try {
+    const response = await fetch(`${API_BASE}/list/${encodeURIComponent(folder)}`);
+    if (!response.ok) {
+      throw new Error('Unable to load files');
+    }
+    const data = await response.json();
+    renderFileList(data.files || []);
+  } catch (error) {
+    renderError(fileList, error.message);
+  }
+}
+
+async function fetchFileContent(folder, file) {
+  try {
+    const response = await fetch(`${API_BASE}/file/${encodeURIComponent(folder)}/${encodeURIComponent(file)}`);
+    if (!response.ok) {
+      const errorPayload = await response.json().catch(() => ({}));
+      throw new Error(errorPayload.error || 'Unable to load file');
+    }
+    const text = await response.text();
+    renderPreview(text);
+  } catch (error) {
+    renderError(preview, error.message);
+  }
+}
+
+loadFolders();


### PR DESCRIPTION
## Summary
- add a dependency-free Node.js API for listing and reading boss workspace folders via the path resolver
- scaffold a static boss workspace UI with folder navigation, file listing, and inline previews
- document an end-to-end smoke test and provide environment samples for the new API service

## Testing
- node --check boss-api/server.js

------
https://chatgpt.com/codex/tasks/task_e_68dc228ed84c8329b40b391f1a8cb30c