### PR TITLE
Add boss-api proxy server and boss-ui console scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 cleanup_home_backups.sh
+boss-api/node_modules
+boss-api/package-lock.json
+boss-api/.env

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ python3 -m http.server 8080
 open http://localhost:8080
 ```
 
+### Option 4: boss-api + boss-ui scaffold
+```bash
+cd boss-api
+npm install
+npm run start
+# → http://localhost:7010 serves the API and static boss-ui client
+```
+
+The API automatically proxies chat requests to configured gateways. Edit environment variables such as `MCP_DOCKER_URL`, `MCP_FS_URL`, and `OLLAMA_URL` to point at your runtime services. The paired UI lives in `boss-ui/` and is published via the Express static middleware.
+
 ## 🔧 Available Scripts
 
 | Script | Purpose |

--- a/boss-api/package.json
+++ b/boss-api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "boss-api",
+  "version": "0.1.0",
+  "description": "02luka API gateway bridge",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "NODE_ENV=development node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "morgan": "^1.10.0"
+  }
+}

--- a/boss-api/server.js
+++ b/boss-api/server.js
@@ -1,0 +1,209 @@
+const express = require('express');
+const cors = require('cors');
+const morgan = require('morgan');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const app = express();
+
+const PORT = Number.parseInt(process.env.PORT || process.env.BOSS_API_PORT || '7010', 10);
+const HOST = process.env.HOST || '0.0.0.0';
+const UI_ROOT = process.env.UI_ROOT || path.join(__dirname, '..', 'boss-ui');
+
+const defaultGateways = {
+  mcpDocker: process.env.MCP_DOCKER_URL || 'http://127.0.0.1:5012',
+  mcpFs: process.env.MCP_FS_URL || 'http://127.0.0.1:8765',
+  ollama: process.env.OLLAMA_URL || 'http://127.0.0.1:11434'
+};
+
+const gatewayAliases = new Map([
+  ['mcpdocker', 'mcpDocker'],
+  ['mcp-docker', 'mcpDocker'],
+  ['mcp', 'mcpDocker'],
+  ['docker', 'mcpDocker'],
+  ['mcpfs', 'mcpFs'],
+  ['fs', 'mcpFs'],
+  ['fs-mcp', 'mcpFs'],
+  ['ollama', 'ollama']
+]);
+
+const corsOrigins = (process.env.CORS_ORIGINS || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+if (corsOrigins.length > 0) {
+  app.use(
+    cors({
+      origin(origin, callback) {
+        if (!origin || corsOrigins.includes(origin)) {
+          callback(null, true);
+        } else {
+          callback(new Error('Not allowed by CORS'));
+        }
+      }
+    })
+  );
+} else {
+  app.use(cors());
+}
+
+app.use(express.json({ limit: '5mb' }));
+app.use(morgan(process.env.NODE_ENV === 'production' ? 'combined' : 'dev'));
+
+if (fs.existsSync(UI_ROOT)) {
+  app.use(express.static(UI_ROOT));
+}
+
+function resolveGateway(input) {
+  if (!input) {
+    throw new Error('Gateway is required');
+  }
+
+  const key = gatewayAliases.get(input.toLowerCase()) || input;
+  const target = defaultGateways[key];
+
+  if (!target) {
+    throw new Error(`Unknown gateway: ${input}`);
+  }
+
+  return { key, url: target };
+}
+
+function pickHeaders(headers) {
+  if (!headers || typeof headers !== 'object') {
+    return {};
+  }
+
+  const allowed = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      allowed[name.toLowerCase()] = value;
+    }
+  }
+  return allowed;
+}
+
+function isJson(headers) {
+  const contentType = headers.get('content-type');
+  return contentType && contentType.includes('application/json');
+}
+
+app.get('/health', (req, res) => {
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+    gateways: defaultGateways
+  });
+});
+
+app.get('/config', (req, res) => {
+  res.json({
+    gateways: defaultGateways,
+    cors: corsOrigins,
+    updatedAt: new Date().toISOString()
+  });
+});
+
+app.post('/chat', async (req, res, next) => {
+  try {
+    const {
+      gateway,
+      path: gatewayPath,
+      method = 'POST',
+      payload,
+      headers,
+      timeoutMs = 90_000
+    } = req.body || {};
+
+    if (!gatewayPath || typeof gatewayPath !== 'string') {
+      return res.status(400).json({ error: 'path is required' });
+    }
+
+    const { url: baseUrl, key } = resolveGateway(gateway);
+    const target = new URL(gatewayPath, baseUrl);
+
+    const upperMethod = method.toUpperCase();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    const outgoingHeaders = pickHeaders(headers);
+    const fetchOptions = {
+      method: upperMethod,
+      headers: outgoingHeaders,
+      signal: controller.signal
+    };
+
+    if (upperMethod !== 'GET' && upperMethod !== 'HEAD') {
+      if (payload === undefined || payload === null) {
+        fetchOptions.body = undefined;
+      } else if (typeof payload === 'string') {
+        fetchOptions.body = payload;
+      } else {
+        fetchOptions.body = JSON.stringify(payload);
+        if (!outgoingHeaders['content-type']) {
+          fetchOptions.headers['content-type'] = 'application/json';
+        }
+      }
+    }
+
+    let response;
+    try {
+      response = await fetch(target, fetchOptions);
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const responseHeaders = response.headers;
+    let body;
+
+    if (isJson(responseHeaders)) {
+      body = await response.json();
+    } else {
+      body = await response.text();
+    }
+
+    res.status(response.status).json({
+      gateway: key,
+      url: target.toString(),
+      status: response.status,
+      ok: response.ok,
+      headers: Object.fromEntries(responseHeaders.entries()),
+      body
+    });
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      return res.status(504).json({ error: 'Gateway timeout', details: 'Upstream did not respond in time' });
+    }
+
+    next(error);
+  }
+});
+
+app.use((req, res, next) => {
+  if (!fs.existsSync(UI_ROOT)) {
+    return next();
+  }
+
+  if (req.method === 'GET' && req.accepts('html')) {
+    const indexPath = path.join(UI_ROOT, 'index.html');
+    if (fs.existsSync(indexPath)) {
+      return res.sendFile(indexPath);
+    }
+  }
+
+  return next();
+});
+
+app.use((err, req, res, _next) => {
+  console.error('[boss-api] error', err);
+  const status = err.status || 500;
+  res.status(status).json({
+    error: err.message || 'Internal Server Error'
+  });
+});
+
+app.listen(PORT, HOST, () => {
+  console.log(`boss-api listening on http://${HOST}:${PORT}`);
+});

--- a/boss-ui/app.js
+++ b/boss-ui/app.js
@@ -1,0 +1,186 @@
+const gatewaySelect = document.querySelector('#gateway-select');
+const pathInput = document.querySelector('#path-input');
+const methodSelect = document.querySelector('#method-select');
+const payloadInput = document.querySelector('#payload-input');
+const headersInput = document.querySelector('#headers-input');
+const timeoutInput = document.querySelector('#timeout-input');
+const statusIndicator = document.querySelector('#status-indicator');
+const responseOutput = document.querySelector('#response-output');
+const configTimestamp = document.querySelector('#config-timestamp');
+const copyResponseButton = document.querySelector('#copy-response');
+const chatForm = document.querySelector('#chat-form');
+const clearButton = document.querySelector('#clear-button');
+
+function setStatus(message, variant = 'info') {
+  statusIndicator.textContent = message;
+  statusIndicator.classList.remove('status--ok', 'status--error');
+
+  if (variant === 'ok') {
+    statusIndicator.classList.add('status--ok');
+  } else if (variant === 'error') {
+    statusIndicator.classList.add('status--error');
+  }
+}
+
+function safeParseJson(text) {
+  if (!text || !text.trim()) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Invalid JSON: ${error.message}`);
+  }
+}
+
+function populateGateways(gateways) {
+  gatewaySelect.innerHTML = '';
+
+  const entries = Object.entries(gateways);
+
+  if (entries.length === 0) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'No gateways available';
+    gatewaySelect.appendChild(option);
+    gatewaySelect.disabled = true;
+    return;
+  }
+
+  for (const [key, url] of entries) {
+    const option = document.createElement('option');
+    option.value = key;
+    option.textContent = `${key} → ${url}`;
+    gatewaySelect.appendChild(option);
+  }
+
+  gatewaySelect.disabled = false;
+}
+
+async function loadConfig() {
+  try {
+    const response = await fetch('/config');
+    if (!response.ok) {
+      throw new Error(`Request failed (${response.status})`);
+    }
+
+    const payload = await response.json();
+    populateGateways(payload.gateways || {});
+    configTimestamp.textContent = new Date(payload.updatedAt || Date.now()).toLocaleString();
+    setStatus('Connected to boss-api', 'ok');
+  } catch (error) {
+    console.error('Failed to load config', error);
+    populateGateways({});
+    setStatus(`Config error: ${error.message}`, 'error');
+  }
+}
+
+function formatResponse(data) {
+  if (data == null) {
+    return 'No response payload.';
+  }
+
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  return JSON.stringify(data, null, 2);
+}
+
+chatForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  const gateway = gatewaySelect.value;
+  const pathValue = pathInput.value.trim();
+  const method = methodSelect.value;
+  const timeoutMs = Number.parseInt(timeoutInput.value, 10) || 90_000;
+
+  if (!gateway) {
+    setStatus('Select a gateway before sending.', 'error');
+    return;
+  }
+
+  if (!pathValue) {
+    setStatus('Path is required.', 'error');
+    return;
+  }
+
+  let headers;
+  let payload;
+
+  try {
+    headers = safeParseJson(headersInput.value);
+  } catch (error) {
+    setStatus(error.message, 'error');
+    return;
+  }
+
+  try {
+    const parsed = safeParseJson(payloadInput.value);
+    payload = parsed === undefined ? payloadInput.value : parsed;
+  } catch (error) {
+    setStatus(error.message, 'error');
+    return;
+  }
+
+  const requestBody = {
+    gateway,
+    path: pathValue,
+    method,
+    timeoutMs
+  };
+
+  if (headers) {
+    requestBody.headers = headers;
+  }
+
+  if (payloadInput.value.trim()) {
+    requestBody.payload = payload;
+  }
+
+  setStatus('Sending request…');
+  responseOutput.textContent = 'Awaiting response…';
+
+  try {
+    const response = await fetch('/chat', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(requestBody)
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      throw new Error(data?.error || `Request failed (${response.status})`);
+    }
+
+    responseOutput.textContent = formatResponse(data);
+    setStatus('Request completed', 'ok');
+  } catch (error) {
+    console.error('Request error', error);
+    responseOutput.textContent = error.message;
+    setStatus(`Error: ${error.message}`, 'error');
+  }
+});
+
+copyResponseButton.addEventListener('click', async () => {
+  try {
+    await navigator.clipboard.writeText(responseOutput.textContent);
+    setStatus('Response copied to clipboard', 'ok');
+  } catch (error) {
+    console.error('Clipboard error', error);
+    setStatus('Unable to copy response', 'error');
+  }
+});
+
+clearButton.addEventListener('click', () => {
+  payloadInput.value = '';
+  headersInput.value = '';
+  responseOutput.textContent = 'No response yet.';
+  setStatus('Cleared payload and response');
+});
+
+loadConfig();

--- a/boss-ui/index.html
+++ b/boss-ui/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>02luka Boss UI</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>02luka Gateway Console</h1>
+      <div class="status" id="status-indicator" aria-live="polite">Loading config…</div>
+    </header>
+
+    <main class="app-main">
+      <section class="panel panel--left">
+        <h2>Gateway</h2>
+        <label class="field">
+          <span>Select target</span>
+          <select id="gateway-select"></select>
+        </label>
+        <label class="field">
+          <span>Path</span>
+          <input id="path-input" type="text" value="/v1/chat/completions" />
+        </label>
+        <label class="field">
+          <span>Method</span>
+          <select id="method-select">
+            <option value="POST" selected>POST</option>
+            <option value="GET">GET</option>
+          </select>
+        </label>
+        <label class="field">
+          <span>Timeout (ms)</span>
+          <input id="timeout-input" type="number" min="1000" step="500" value="90000" />
+        </label>
+        <details class="accordion">
+          <summary>Headers</summary>
+          <textarea id="headers-input" placeholder="{\n  &quot;content-type&quot;: &quot;application/json&quot;\n}"></textarea>
+        </details>
+      </section>
+
+      <section class="panel panel--right">
+        <form id="chat-form" class="chat-form">
+          <label class="field">
+            <span>Payload</span>
+            <textarea id="payload-input" rows="8" placeholder='{"messages":[{"role":"user","content":"Hello"}]}'></textarea>
+          </label>
+          <div class="form-actions">
+            <button type="submit" class="btn btn--primary">Send</button>
+            <button type="button" id="clear-button" class="btn">Clear</button>
+          </div>
+        </form>
+
+        <section class="response" aria-live="polite">
+          <header class="response__header">
+            <h2>Response</h2>
+            <button type="button" id="copy-response" class="btn btn--ghost">Copy</button>
+          </header>
+          <pre id="response-output" class="response__body">No response yet.</pre>
+        </section>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <small>Connected to boss-api • <span id="config-timestamp">--</span></small>
+    </footer>
+
+    <script src="./app.js" type="module"></script>
+  </body>
+</html>

--- a/boss-ui/styles.css
+++ b/boss-ui/styles.css
@@ -1,0 +1,216 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #101218;
+  --bg-panel: #1c1f2b;
+  --bg-panel-alt: #222635;
+  --text: #f4f6ff;
+  --text-muted: #a1a8c7;
+  --accent: #7f9bff;
+  --accent-strong: #5673ff;
+  --border: rgba(126, 134, 158, 0.25);
+  --danger: #ff6b6b;
+  --success: #4ade80;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app-header {
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
+  gap: 1rem;
+}
+
+.app-main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+.app-footer {
+  padding: 1rem 1.5rem;
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel--right {
+  background: var(--bg-panel-alt);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.field span {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+select,
+input,
+textarea {
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.02);
+  color: inherit;
+  font: inherit;
+  resize: vertical;
+}
+
+textarea {
+  min-height: 160px;
+}
+
+textarea:focus,
+input:focus,
+select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.accordion {
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+}
+
+.accordion textarea {
+  width: 100%;
+  margin-top: 0.75rem;
+  min-height: 120px;
+}
+
+.chat-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0b1020;
+  border: none;
+  font-weight: 600;
+}
+
+.btn--primary:hover {
+  filter: brightness(1.05);
+}
+
+.btn--ghost {
+  border: none;
+  color: var(--text-muted);
+}
+
+.response {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.response__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.response__body {
+  margin: 0;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  max-height: 420px;
+  overflow: auto;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.status {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.status--ok {
+  color: var(--success);
+}
+
+.status--error {
+  color: var(--danger);
+}
+
+@media (max-width: 960px) {
+  .app-main {
+    grid-template-columns: 1fr;
+  }
+
+  .panel--left,
+  .panel--right {
+    min-height: unset;
+  }
+}

--- a/run/daily_reports/REPORT_2025-10-01.md
+++ b/run/daily_reports/REPORT_2025-10-01.md
@@ -1,0 +1,46 @@
+# Daily Change Report – 2025-10-01
+Generated: 2025-10-01 02:46 +07 (Asia/Bangkok)
+
+## Summary
+- Commits: 2
+- Files changed: 14
+- Lines added: 423
+- Lines removed: 0
+- Tag changes by area:
+  - boss-api: _none_
+  - boss-ui: _none_
+  - .codex: PREPROMPT, guardrails, path keys, task recipes, environment config, and preflight script scaffolding landed.
+  - g/tools: Added mapping drift guard and path resolver utilities tied to workspace governance.
+  - f/ai_context: Seeded logical→physical path mapping JSON for resolver support.
+
+## Commits
+| Time (ICT) | Hash | Author | Subject |
+| --- | --- | --- | --- |
+| 2025-10-01 02:44 | af140aa | Codex | Add daily change report for 2025-10-01 |
+| 2025-10-01 01:07 | f864998 | icmini | Codex scaffolding ready: PREPROMPT, guardrails, preflight; mapping v1.0 OK; resolver + drift guard |
+
+## Key changes
+- **.codex** – Established PREPROMPT, CONTEXT_SEED, PATH_KEYS, GUARDRAILS, TASK_RECIPES, and codex.env.yml to formalize agent conduct and environment expectations; rerun `.codex/preflight.sh` after pulling to ensure compliance (**re-run required**).
+- **g/tools** – Introduced `g/tools/path_resolver.sh` and `g/tools/mapping_drift_guard.sh` so workflows can translate logical keys and detect mapping drift early.
+- **f/ai_context** – Added `f/ai_context/mapping.json` as the canonical key→path lookup powering the new resolver tooling.
+
+## Follow-ups / TODO
+- Run `.codex/preflight.sh` and address any reported setup gaps before executing tasks.
+- Validate workspace mappings with `g/tools/mapping_drift_guard.sh --validate` and monitor for drift each deployment.
+- Document resolver usage patterns in developer onboarding and update examples referencing the new mapping file.
+- Automate daily report generation to prevent manual drift and ensure future coverage of all commits.
+- Review the new reporting process and integrate it with existing operational checklists.
+
+## Quick Runbook
+### Run API/UI
+- API: `bash g/tools/path_resolver.sh boss:api` (resolve target) then start service per resolved path instructions.
+- UI: `./run_local.sh` to launch the local interface at http://localhost:8080.
+- Remote access: `./tunnel` to create and refresh externally accessible URLs.
+- Health checks: `./verify_system.sh` before exposing services publicly.
+
+### Next 5 actions
+1. Pull latest changes and rerun `.codex/preflight.sh`.
+2. Execute `g/tools/mapping_drift_guard.sh --validate` and capture the results in run logs.
+3. Test `g/tools/path_resolver.sh` against key paths (e.g., `human:inbox`, `reports.system`).
+4. Update onboarding/docs with resolver + guardrail instructions and link to this report.
+5. Schedule tomorrow's report generation and confirm stakeholders receive it.


### PR DESCRIPTION
## Summary
- add an Express-based boss-api service that proxies chat requests to configured gateways and serves the static UI bundle
- scaffold a boss-ui console for composing requests, viewing responses, and copying results
- document the new stack in the README and ignore local Node artifacts for the API workspace

## Testing
- node --check boss-api/server.js

------
https://chatgpt.com/codex/tasks/task_e_68dc310300148329a92c85313c1e5383