### PR TITLE
Add prompt optimizer endpoint and Luka UI integration

### DIFF
--- a/boss-api/server.js
+++ b/boss-api/server.js
@@ -13,10 +13,443 @@ function writeJson(res, code, payload) {
   res.writeHead(code, {
     'Content-Type': 'application/json; charset=utf-8',
     'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET,OPTIONS',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type'
   });
   res.end(body);
+}
+
+function clampScore(value) {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return Number(value.toFixed(3));
+}
+
+function normalizeWhitespace(text) {
+  return text.replace(/[ \t]+/g, ' ').replace(/\s+\n/g, '\n').trim();
+}
+
+function ensureSentence(text) {
+  if (!text) return '';
+  const trimmed = text.trim();
+  if (!trimmed) return '';
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+function stripBulletPrefix(line) {
+  return line.replace(/^\s*(?:[-*]|\d+[.)])\s*/, '').trim();
+}
+
+function dedupeStrings(items) {
+  const seen = new Set();
+  const result = [];
+  for (const item of items) {
+    const normalized = item.trim();
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function analyzePromptStructure(promptText) {
+  const text = (promptText || '').replace(/\r/g, '');
+  const normalized = text.toLowerCase();
+  const words = normalized.split(/\s+/).filter(Boolean);
+  const wordCount = words.length;
+  const headings = (text.match(/(^|\n)\s*(?:#{2,}|[A-Z][A-Z\s]{3,}:)/g) || []).length;
+  const bulletCount = (text.match(/(^|\n)\s*(?:[-*]|\d+[.)])\s+/g) || []).length;
+  const hasYouAre = /\byou are\b|\bact as\b/i.test(text);
+  const hasDeliverable = /\bdeliverable\b|\boutput\b|\breturn\b|\bprovide\b|\breport\b|\bsubmit\b/i.test(normalized);
+  const hasQuality = /\bquality\b|\bsuccess\b|\bdefinition of done\b|\bacceptance\b|\bverify\b/i.test(normalized);
+  const hasCallToAction = /\bplan\b|\bexecute\b|\banalyze\b|\brespond\b|\bprepare\b|\bdraft\b|\bdeliver\b|\bproduce\b/i.test(normalized);
+  const hasContext = /\bcontext\b|\bbackground\b|\bmission\b|\bgoal\b|\bbrief\b/i.test(normalized);
+  const hasConstraints = /\bconstraint\b|\bdeadline\b|\bmust not\b|\bavoid\b|\bwithout\b|\bdo not\b/i.test(normalized);
+  const hasMetrics = /\bmetric\b|\bscore\b|\bdeadline\b|\bminutes?\b|\bhours?\b|\bday\b|\beta\b/i.test(normalized);
+
+  const readabilityTarget = 180;
+  const readability = clampScore(1 - Math.min(1, Math.abs(wordCount - readabilityTarget) / readabilityTarget));
+
+  let score = 0.35;
+  score += Math.min(0.25, readability * 0.25);
+  if (wordCount > 50) score += 0.05;
+  if (headings > 0) score += 0.08;
+  if (bulletCount > 0) score += 0.1;
+  if (hasDeliverable) score += 0.08;
+  if (hasQuality) score += 0.07;
+  if (hasCallToAction) score += 0.07;
+  if (hasContext) score += 0.05;
+  if (hasConstraints) score += 0.05;
+  if (hasYouAre) score += 0.03;
+  if (hasMetrics) score += 0.02;
+
+  return {
+    wordCount,
+    headings,
+    bulletCount,
+    hasYouAre,
+    hasDeliverable,
+    hasQuality,
+    hasCallToAction,
+    hasContext,
+    hasConstraints,
+    hasMetrics,
+    readability,
+    score: clampScore(score)
+  };
+}
+
+function computeFeatureDelta(targetFeatures, baselineFeatures) {
+  if (!baselineFeatures) return {};
+  const delta = {
+    score: Number((targetFeatures.score - baselineFeatures.score).toFixed(3))
+  };
+
+  const booleanKeys = ['hasYouAre', 'hasDeliverable', 'hasQuality', 'hasCallToAction', 'hasContext', 'hasConstraints', 'hasMetrics'];
+  for (const key of booleanKeys) {
+    if (typeof targetFeatures[key] === 'boolean' && typeof baselineFeatures[key] === 'boolean') {
+      delta[key] = targetFeatures[key] === baselineFeatures[key]
+        ? 0
+        : (targetFeatures[key] ? 1 : -1);
+    }
+  }
+
+  const numericKeys = ['wordCount', 'headings', 'bulletCount'];
+  for (const key of numericKeys) {
+    if (typeof targetFeatures[key] === 'number' && typeof baselineFeatures[key] === 'number') {
+      delta[key] = Number((targetFeatures[key] - baselineFeatures[key]).toFixed(2));
+    }
+  }
+
+  return delta;
+}
+
+function extractRoleLine(promptText) {
+  const match = promptText.match(/you are[^\n.]*[\n.]?/i);
+  if (match) {
+    return ensureSentence(normalizeWhitespace(match[0]));
+  }
+  const firstLine = promptText.split(/\n/).map((line) => line.trim()).find(Boolean);
+  if (firstLine) {
+    if (/act as|pretend/i.test(firstLine)) {
+      return ensureSentence(firstLine);
+    }
+    return ensureSentence(`You are ${firstLine}`);
+  }
+  return 'You are Luka, a decisive autonomous operator coordinating expert AI systems.';
+}
+
+function parsePromptComponents(promptText) {
+  const cleaned = (promptText || '').replace(/\r/g, '');
+  const lines = cleaned.split(/\n/);
+  const bulletLines = lines.filter((line) => /^\s*(?:[-*]|\d+[.)])\s+/.test(line)).map(stripBulletPrefix);
+  const nonBulletLines = lines.filter((line) => !/^\s*(?:[-*]|\d+[.)])\s+/.test(line));
+  const paragraphs = nonBulletLines.join('\n').split(/\n\s*\n/).map((block) => block.trim()).filter(Boolean);
+  const sentences = paragraphs.flatMap((para) => para.split(/(?<=[.!?])\s+/)).map((item) => item.trim()).filter(Boolean);
+  const deliverableLines = lines
+    .filter((line) => /\bdeliverable\b|\boutput\b|\breturn\b|\bprovide\b|\breport\b|\bsubmit\b|\bproduce\b|\bshare\b/i.test(line))
+    .map(stripBulletPrefix);
+  const constraintSentences = sentences.filter((line) => /\bmust\b|\bmust not\b|\bavoid\b|\bconstraint\b|\bdeadline\b|\bwithout\b|\bdo not\b/i.test(line));
+  const questionSentences = sentences.filter((line) => /\?/g.test(line));
+  const resourceLines = lines.filter((line) => /\btool\b|\bresource\b|\bapi\b|\bdatabase\b|\bdocument\b|\blink\b/i.test(line)).map(stripBulletPrefix);
+  const summaryParagraph = paragraphs[0] || '';
+  return {
+    lines,
+    bulletLines,
+    paragraphs,
+    sentences,
+    deliverableLines,
+    constraintSentences,
+    questionSentences,
+    resourceLines,
+    summaryParagraph
+  };
+}
+
+function ensureNumberedList(items) {
+  const unique = dedupeStrings(items).slice(0, 6);
+  const finalItems = unique.length > 0 ? unique : [
+    'Clarify the mission objectives and missing context.',
+    'Draft a step-by-step action plan before execution.',
+    'Execute tasks decisively while documenting key findings.',
+    'Report progress, blockers, and recommended next actions.'
+  ];
+  return finalItems.map((item, index) => `${index + 1}. ${ensureSentence(stripBulletPrefix(item))}`);
+}
+
+function ensureBulletList(items, options = {}) {
+  const prefix = options.checkbox ? '- [ ] ' : '- ';
+  const unique = dedupeStrings(items).slice(0, options.limit || 6);
+  const fallback = options.fallback || [
+    'Summarize the current understanding and assumptions.',
+    'List concrete next actions or questions to resolve.',
+    'Flag risks or blockers that need attention.'
+  ];
+  const source = unique.length > 0 ? unique : fallback;
+  return source.map((item) => `${prefix}${stripBulletPrefix(item)}`);
+}
+
+function buildStructuredVariant(promptText, components) {
+  const roleLine = extractRoleLine(promptText);
+  const mission = components.summaryParagraph || ensureSentence('Deliver a decisive plan that solves the mission.');
+  const procedure = ensureNumberedList(components.bulletLines);
+  const constraintsList = ensureBulletList(components.constraintSentences, {
+    fallback: ['Call out any constraints or dependencies you identify.']
+  });
+  const deliverables = ensureBulletList(components.deliverableLines, {
+    fallback: [
+      'Provide a concise mission report covering actions taken, key findings, and outcomes.',
+      'List the top-priority next moves or requests for clarification.'
+    ]
+  });
+
+  const prompt = [
+    '## Role',
+    roleLine,
+    '## Mission Brief',
+    mission,
+    '## Constraints',
+    constraintsList.join('\n'),
+    '## Operating Procedure',
+    procedure.join('\n'),
+    '## Deliverables',
+    deliverables.join('\n'),
+    '## Quality Bar',
+    '- Cross-check each deliverable for accuracy before finalizing.\n- Surface any risks, blockers, or open questions with owner-ready language.'
+  ].join('\n\n');
+
+  return {
+    id: 'structured-brief',
+    title: 'Structured mission brief',
+    summary: 'Adds Role, Mission, Constraints, Procedure, Deliverables, and Quality sections for a crisp battle plan.',
+    improvements: [
+      'Introduces a mission brief template to frame the ask.',
+      'Normalizes steps into a numbered operating procedure.',
+      'Clarifies expected deliverables and success checks.'
+    ],
+    prompt
+  };
+}
+
+function buildChecklistVariant(promptText, components) {
+  const summary = components.summaryParagraph || ensureSentence('Execute quickly while maintaining communication.');
+  const actions = ensureBulletList(components.bulletLines.length ? components.bulletLines : components.sentences, {
+    checkbox: true,
+    fallback: [
+      'Draft an initial action plan and confirm with stakeholders.',
+      'Execute the plan, keeping a log of decisions and learnings.',
+      'Reconcile outputs against the mission goals before delivering.'
+    ]
+  });
+  const checkpoints = ensureBulletList(components.questionSentences, {
+    fallback: [
+      'T+15m: Confirm understanding of the mission and surface missing information.',
+      'T+30m: Share progress snapshot with any early findings.',
+      'T+60m: Deliver refined output and proposed next moves.'
+    ]
+  });
+  const deliverables = ensureBulletList(components.deliverableLines, {
+    fallback: [
+      'Final response must include a concise summary, key evidence, and prioritized next steps.',
+      'Highlight blockers or open questions separately from the main answer.'
+    ]
+  });
+
+  const prompt = [
+    '### Mission Summary',
+    summary,
+    '### Action Checklist',
+    actions.join('\n'),
+    '### Checkpoints & Comms Rhythm',
+    checkpoints.join('\n'),
+    '### Completion Criteria',
+    deliverables.join('\n'),
+    '### Closing Loop',
+    '- Close with confidence level, outstanding risks, and the next recommended push.'
+  ].join('\n\n');
+
+  return {
+    id: 'checklist',
+    title: 'Checklist with comms rhythm',
+    summary: 'Turns the mission into checkboxes with explicit time-boxed updates and completion criteria.',
+    improvements: [
+      'Establishes a communication cadence for progress signals.',
+      'Adds checkbox-style actions to drive accountability.',
+      'Defines how to wrap with confidence, risks, and next steps.'
+    ],
+    prompt
+  };
+}
+
+function buildNorthStarVariant(promptText, components) {
+  const roleLine = extractRoleLine(promptText);
+  const mission = components.summaryParagraph || ensureSentence('Deliver a high-signal answer that unblocks execution.');
+  const resources = ensureBulletList(components.resourceLines, {
+    fallback: ['Leverage available local tools, knowledge bases, and MCP resources as needed.']
+  });
+  const guardrails = ensureBulletList(components.constraintSentences, {
+    fallback: [
+      'Escalate if critical information is missing before making irreversible calls.',
+      'Document assumptions explicitly whenever acting on them.'
+    ]
+  });
+  const deliverables = ensureBulletList(components.deliverableLines, {
+    fallback: [
+      'North Star Output: actionable plan + supporting rationale.',
+      'Next moves list with owners (even if tentative).'
+    ]
+  });
+
+  const prompt = [
+    'SYSTEM ROLE:',
+    roleLine,
+    'OBJECTIVE:',
+    mission,
+    'NORTH STAR OUTPUT:',
+    deliverables.join('\n'),
+    'RESOURCES & LEVERS:',
+    resources.join('\n'),
+    'GUARDRAILS:',
+    guardrails.join('\n'),
+    'SIGN-OFF FORMAT:',
+    '- Begin with a one-line mission status (GREEN / YELLOW / RED).\n- Provide the recommended plan with supporting evidence.\n- List risks, blockers, and explicit asks of stakeholders.'
+  ].join('\n\n');
+
+  return {
+    id: 'north-star',
+    title: 'North Star outcome framing',
+    summary: 'Frames the request around mission objective, resources, guardrails, and expected sign-off structure.',
+    improvements: [
+      'Focuses the assistant on the north-star outcome and evidence.',
+      'Surfaces available levers/resources explicitly.',
+      'Defines sign-off format with status call, plan, and risks.'
+    ],
+    prompt
+  };
+}
+
+function scoreAndEnrichVariant(variant, baselineFeatures) {
+  const features = analyzePromptStructure(variant.prompt);
+  return Object.assign({}, variant, {
+    score: features.score,
+    features,
+    delta: computeFeatureDelta(features, baselineFeatures)
+  });
+}
+
+function generateHeuristicVariants(promptText) {
+  const components = parsePromptComponents(promptText);
+  const baselineFeatures = analyzePromptStructure(promptText);
+  const baseline = {
+    id: 'baseline',
+    title: 'Original prompt',
+    summary: 'As provided by the operator.',
+    prompt: promptText,
+    score: baselineFeatures.score,
+    features: baselineFeatures
+  };
+
+  const rawVariants = [
+    buildStructuredVariant(promptText, components),
+    buildChecklistVariant(promptText, components),
+    buildNorthStarVariant(promptText, components)
+  ];
+
+  const enriched = rawVariants
+    .map((variant) => scoreAndEnrichVariant(variant, baselineFeatures))
+    .sort((a, b) => b.score - a.score);
+
+  return { baseline, variants: enriched };
+}
+
+async function maybeAddModelVariant(promptText, baselineFeatures) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return null;
+
+  const baseUrl = (process.env.OPENAI_BASE_URL || 'https://api.openai.com').replace(/\/+$/, '');
+  const model = process.env.LUKA_OPTIMIZER_MODEL || 'gpt-4o-mini';
+
+  const body = JSON.stringify({
+    model,
+    temperature: 0.3,
+    max_tokens: 900,
+    messages: [
+      {
+        role: 'system',
+        content: 'You refine operator prompts for autonomous AI systems. Return only the improved prompt. Make it structured and actionable.'
+      },
+      {
+        role: 'user',
+        content: `Rewrite the following prompt so it is crisp, structured, and ready for an elite AI operator. Keep all critical details.\n\n${promptText}`
+      }
+    ]
+  });
+
+  try {
+    const response = await httpRequestJson(`${baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body,
+      timeout: 20000
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      return null;
+    }
+
+    const parsed = response.body ? JSON.parse(response.body) : {};
+    const text = extractTextFromPayload(parsed);
+    if (!text) return null;
+
+    const cleaned = text.trim();
+    if (!cleaned) return null;
+
+    const variant = {
+      id: 'model-rewrite',
+      title: `Model rewrite (${model})`,
+      summary: 'Rewritten via remote model for additional polish.',
+      improvements: [
+        'Applies LLM-driven restructuring with the latest context.',
+        'Maintains mission intent while tightening instructions.'
+      ],
+      prompt: cleaned,
+      source: 'model',
+      meta: { provider: 'openai', model }
+    };
+
+    return scoreAndEnrichVariant(variant, baselineFeatures);
+  } catch (err) {
+    console.warn('[boss-api] optimize_prompt model call failed', err.message || err);
+    return null;
+  }
+}
+
+async function optimizePrompt(promptText) {
+  const heuristic = generateHeuristicVariants(promptText);
+  const modelVariant = await maybeAddModelVariant(promptText, heuristic.baseline.features);
+  const variants = [...heuristic.variants];
+  if (modelVariant) {
+    variants.push(modelVariant);
+    variants.sort((a, b) => b.score - a.score);
+  }
+
+  return {
+    ok: true,
+    heuristics: 'v1',
+    baseline: heuristic.baseline,
+    variants,
+    meta: {
+      generatedAt: new Date().toISOString(),
+      usingModel: Boolean(modelVariant),
+      model: modelVariant?.meta?.model || null
+    }
+  };
 }
 
 const allowed = new Set(['inbox','sent','deliverables','dropbox','drafts','documents']);
@@ -357,7 +790,7 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {
     res.writeHead(204, {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET,OPTIONS',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type'
     });
     return res.end();
@@ -391,6 +824,37 @@ const server = http.createServer(async (req, res) => {
           } catch (err) {
             console.error('[boss-api] chat orchestration failed', err);
             return writeJson(res, 502, { error: 'Chat orchestration failed', detail: err.message });
+          }
+        } catch (err) {
+          return writeJson(res, 400, { error: 'Invalid JSON payload' });
+        }
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/optimize_prompt') {
+      let raw = '';
+      req.on('data', (chunk) => {
+        raw += chunk;
+        if (raw.length > 1_000_000) {
+          req.destroy();
+        }
+      });
+
+      req.on('end', async () => {
+        try {
+          const payload = raw ? JSON.parse(raw) : {};
+          const prompt = (payload.prompt || payload.message || '').trim();
+          if (!prompt) {
+            return writeJson(res, 400, { error: 'prompt is required' });
+          }
+
+          try {
+            const result = await optimizePrompt(prompt);
+            return writeJson(res, 200, result);
+          } catch (err) {
+            console.error('[boss-api] prompt optimization failed', err);
+            return writeJson(res, 502, { error: 'Prompt optimization failed', detail: err.message });
           }
         } catch (err) {
           return writeJson(res, 400, { error: 'Invalid JSON payload' });

--- a/luka.html
+++ b/luka.html
@@ -80,6 +80,9 @@
     .input-area {
       padding: 16px;
       border-top: 1px solid #262626;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
     }
     .input-wrapper {
       background: #141414;
@@ -185,6 +188,147 @@
       border: none;
       color: white;
     }
+
+    .optimizer-results {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      background: #111827;
+      border: 1px solid #1f2937;
+      border-radius: 12px;
+      padding: 16px;
+    }
+
+    .optimizer-results.open {
+      display: flex;
+    }
+
+    .optimizer-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .optimizer-title {
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .optimizer-subtitle {
+      font-size: 12px;
+      color: #94a3b8;
+      margin-top: 4px;
+      max-width: 520px;
+      line-height: 1.5;
+    }
+
+    .optimizer-header-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .optimizer-body {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .optimizer-empty,
+    .optimizer-status-line {
+      font-size: 12px;
+      color: #9ca3af;
+    }
+
+    .optimizer-cards {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .optimizer-card {
+      background: #0b1120;
+      border: 1px solid #1e293b;
+      border-radius: 12px;
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .optimizer-card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .optimizer-card-title {
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    .optimizer-card-metrics {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .optimizer-card-score {
+      font-size: 12px;
+      font-weight: 600;
+      color: #22c55e;
+      background: rgba(34, 197, 94, 0.12);
+      padding: 2px 8px;
+      border-radius: 999px;
+    }
+
+    .optimizer-card-delta {
+      font-size: 12px;
+      padding: 2px 8px;
+      border-radius: 999px;
+    }
+
+    .optimizer-card-delta.positive {
+      color: #34d399;
+      background: rgba(52, 211, 153, 0.12);
+    }
+
+    .optimizer-card-delta.negative {
+      color: #f97316;
+      background: rgba(249, 115, 22, 0.12);
+    }
+
+    .optimizer-card-summary {
+      font-size: 12px;
+      color: #e2e8f0;
+      line-height: 1.6;
+    }
+
+    .optimizer-card-list {
+      padding-left: 16px;
+      font-size: 12px;
+      color: #cbd5f5;
+      line-height: 1.6;
+    }
+
+    .optimizer-card-prompt {
+      background: rgba(15, 23, 42, 0.7);
+      border: 1px solid #1e293b;
+      border-radius: 10px;
+      padding: 12px;
+      font-family: 'JetBrains Mono', 'SFMono-Regular', 'Menlo', monospace;
+      font-size: 12px;
+      white-space: pre-wrap;
+      line-height: 1.6;
+      color: #e0f2fe;
+    }
+
+    .optimizer-card-actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
   </style>
 </head>
 <body>
@@ -202,6 +346,7 @@
         <option value="ollama">Ollama (11434)</option>
       </select>
       <button class="tool-button" id="promptLibraryButton" type="button">Prompt Library</button>
+      <button class="tool-button" id="optimizePromptButton" type="button">Optimize Current</button>
     </div>
   </header>
 
@@ -235,6 +380,20 @@
         </svg>
       </button>
     </div>
+    <div class="optimizer-results" id="optimizerResults">
+      <div class="optimizer-header">
+        <div>
+          <div class="optimizer-title">Prompt Optimizer</div>
+          <div class="optimizer-subtitle" id="optimizerSummary">Generate ranked variants before dispatching.</div>
+        </div>
+        <div class="optimizer-header-actions">
+          <button class="tool-button secondary" id="optimizerClear" type="button">Clear</button>
+        </div>
+      </div>
+      <div class="optimizer-body" id="optimizerBody">
+        <div class="optimizer-empty">No variants yet. Run the optimizer to see suggestions.</div>
+      </div>
+    </div>
   </div>
 
   <script>
@@ -248,8 +407,14 @@
     const closePromptLibrary = document.getElementById('closePromptLibrary');
     const copyPromptTemplate = document.getElementById('copyPromptTemplate');
     const insertPromptTemplate = document.getElementById('insertPromptTemplate');
+    const optimizePromptButton = document.getElementById('optimizePromptButton');
+    const optimizerResults = document.getElementById('optimizerResults');
+    const optimizerSummary = document.getElementById('optimizerSummary');
+    const optimizerBody = document.getElementById('optimizerBody');
+    const optimizerClear = document.getElementById('optimizerClear');
 
     const BACKEND_CHAT_URL = (window.LUKA_BACKEND && window.LUKA_BACKEND.chatEndpoint) || 'http://127.0.0.1:4000/api/chat';
+    const BACKEND_OPTIMIZE_URL = (window.LUKA_BACKEND && window.LUKA_BACKEND.optimizeEndpoint) || 'http://127.0.0.1:4000/api/optimize_prompt';
     const TARGET_PROFILES = {
       auto: {
         id: 'auto',
@@ -274,12 +439,185 @@
     };
 
     let masterPromptCache = '';
+    const optimizeButtonDefaultText = optimizePromptButton ? optimizePromptButton.textContent : 'Optimize Current';
+    const optimizerState = {
+      loading: false,
+      lastResult: null
+    };
 
     function togglePromptLibrary(forceOpen) {
       const shouldOpen = forceOpen ?? !promptLibraryPanel.classList.contains('open');
       promptLibraryPanel.classList.toggle('open', shouldOpen);
     }
 
+    function resetOptimizerPanel() {
+      optimizerState.lastResult = null;
+      optimizerSummary.textContent = 'Generate ranked variants before dispatching.';
+      optimizerBody.innerHTML = '<div class="optimizer-empty">No variants yet. Run the optimizer to see suggestions.</div>';
+      optimizerResults.classList.remove('open');
+    }
+
+    function showOptimizerPanel() {
+      optimizerResults.classList.add('open');
+    }
+
+    function setOptimizeButtonLoading(isLoading) {
+      optimizerState.loading = isLoading;
+      if (!optimizePromptButton) return;
+      optimizePromptButton.disabled = isLoading;
+      optimizePromptButton.textContent = isLoading ? 'Optimizing…' : optimizeButtonDefaultText;
+    }
+
+    function showOptimizerLoading(message) {
+      showOptimizerPanel();
+      optimizerSummary.textContent = message;
+      optimizerBody.innerHTML = `<div class="optimizer-status-line">${message}</div>`;
+    }
+
+    function formatScore(value) {
+      if (!Number.isFinite(value)) return '—';
+      return `${Math.round(value * 100)}`;
+    }
+
+    function formatDelta(value) {
+      if (!Number.isFinite(value) || value === 0) return '0';
+      const magnitude = Math.round(Math.abs(value) * 100);
+      return `${value > 0 ? '+' : '-'}${magnitude}`;
+    }
+
+    function createVariantCard(variant, index) {
+      const card = document.createElement('div');
+      card.className = 'optimizer-card';
+
+      const header = document.createElement('div');
+      header.className = 'optimizer-card-header';
+
+      const title = document.createElement('div');
+      title.className = 'optimizer-card-title';
+      title.textContent = `#${index + 1} ${variant.title}`;
+      header.appendChild(title);
+
+      const metrics = document.createElement('div');
+      metrics.className = 'optimizer-card-metrics';
+
+      const score = document.createElement('span');
+      score.className = 'optimizer-card-score';
+      score.textContent = `Score ${formatScore(variant.score)}`;
+      metrics.appendChild(score);
+
+      if (variant.delta && typeof variant.delta.score === 'number' && variant.delta.score !== 0) {
+        const delta = document.createElement('span');
+        delta.className = 'optimizer-card-delta ' + (variant.delta.score > 0 ? 'positive' : 'negative');
+        delta.textContent = formatDelta(variant.delta.score);
+        metrics.appendChild(delta);
+      }
+
+      header.appendChild(metrics);
+      card.appendChild(header);
+
+      if (variant.summary) {
+        const summary = document.createElement('div');
+        summary.className = 'optimizer-card-summary';
+        summary.textContent = variant.summary;
+        card.appendChild(summary);
+      }
+
+      if (Array.isArray(variant.improvements) && variant.improvements.length) {
+        const list = document.createElement('ul');
+        list.className = 'optimizer-card-list';
+        variant.improvements.forEach((item) => {
+          const li = document.createElement('li');
+          li.textContent = item;
+          list.appendChild(li);
+        });
+        card.appendChild(list);
+      }
+
+      const promptBlock = document.createElement('pre');
+      promptBlock.className = 'optimizer-card-prompt';
+      promptBlock.textContent = variant.prompt;
+      card.appendChild(promptBlock);
+
+      const actions = document.createElement('div');
+      actions.className = 'optimizer-card-actions';
+
+      const useButton = document.createElement('button');
+      useButton.className = 'tool-button primary';
+      useButton.type = 'button';
+      useButton.textContent = 'Use this';
+      useButton.addEventListener('click', () => {
+        messageInput.value = variant.prompt;
+        messageInput.dispatchEvent(new Event('input'));
+        messageInput.focus();
+      });
+      actions.appendChild(useButton);
+
+      const copyButton = document.createElement('button');
+      copyButton.className = 'tool-button secondary';
+      copyButton.type = 'button';
+      copyButton.textContent = 'Copy';
+      copyButton.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(variant.prompt);
+          copyButton.textContent = 'Copied!';
+          setTimeout(() => { copyButton.textContent = 'Copy'; }, 1500);
+        } catch (err) {
+          copyButton.textContent = 'Copy failed';
+          setTimeout(() => { copyButton.textContent = 'Copy'; }, 1500);
+        }
+      });
+      actions.appendChild(copyButton);
+
+      card.appendChild(actions);
+      return card;
+    }
+
+    function renderOptimizerResult(payload) {
+      optimizerState.lastResult = payload;
+      showOptimizerPanel();
+
+      const baselineScore = payload?.baseline?.score
+        ?? payload?.baseline?.features?.score
+        ?? 0;
+      const bestVariant = Array.isArray(payload?.variants) && payload.variants.length
+        ? payload.variants[0]
+        : null;
+
+      if (bestVariant) {
+        const delta = typeof bestVariant.delta?.score === 'number'
+          ? bestVariant.delta.score
+          : bestVariant.score - baselineScore;
+        const deltaLabel = formatDelta(delta);
+        const deltaSegment = deltaLabel === '0' ? '' : ` (${deltaLabel})`;
+        const modelSegment = payload?.meta?.usingModel && payload.meta.model
+          ? ` • Model ${payload.meta.model}`
+          : '';
+        optimizerSummary.textContent = `Baseline ${formatScore(baselineScore)} • Top ${bestVariant.title} ${formatScore(bestVariant.score)}${deltaSegment}${modelSegment}`;
+      } else {
+        optimizerSummary.textContent = 'No improved variants were generated. Try expanding the prompt.';
+      }
+
+      optimizerBody.innerHTML = '';
+
+      if (!bestVariant) {
+        optimizerBody.innerHTML = '<div class="optimizer-empty">Optimizer did not produce any alternatives.</div>';
+        return;
+      }
+
+      const cards = document.createElement('div');
+      cards.className = 'optimizer-cards';
+      payload.variants.forEach((variant, index) => {
+        cards.appendChild(createVariantCard(variant, index));
+      });
+      optimizerBody.appendChild(cards);
+    }
+
+    function renderOptimizerError(error) {
+      showOptimizerPanel();
+      const message = error && error.message ? error.message : 'Unknown error';
+      optimizerSummary.textContent = `Optimizer error: ${message}`;
+      optimizerBody.innerHTML = '<div class="optimizer-empty">Unable to produce variants. Verify the backend is running and try again.</div>';
+    }
     async function loadMasterPrompt() {
       if (masterPromptCache) {
         promptLibraryBody.textContent = masterPromptCache;
@@ -357,6 +695,55 @@
 
     sendButton.addEventListener('click', sendMessage);
 
+    if (optimizerClear) {
+      optimizerClear.addEventListener('click', () => {
+        resetOptimizerPanel();
+        if (optimizePromptButton) {
+          optimizePromptButton.focus();
+        }
+      });
+    }
+
+    if (optimizePromptButton) {
+      optimizePromptButton.addEventListener('click', async () => {
+        const text = messageInput.value.trim();
+        if (!text) {
+          showOptimizerPanel();
+          optimizerSummary.textContent = 'Enter a prompt to optimize.';
+          optimizerBody.innerHTML = '<div class="optimizer-empty">Write or paste a prompt above before running the optimizer.</div>';
+          return;
+        }
+
+        setOptimizeButtonLoading(true);
+        showOptimizerLoading('Analyzing prompt…');
+
+        try {
+          const response = await fetch(BACKEND_OPTIMIZE_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt: text })
+          });
+
+          if (!response.ok) {
+            const errorPayload = await safeParseJson(response);
+            const detail = errorPayload && (errorPayload.detail || errorPayload.error);
+            throw new Error(detail || `Optimizer responded with HTTP ${response.status}`);
+          }
+
+          const data = await response.json();
+          if (!data || !Array.isArray(data.variants)) {
+            throw new Error('Optimizer returned an empty payload');
+          }
+
+          renderOptimizerResult(data);
+        } catch (error) {
+          renderOptimizerError(error);
+        } finally {
+          setOptimizeButtonLoading(false);
+        }
+      });
+    }
+
     promptLibraryButton.addEventListener('click', async () => {
       await loadMasterPrompt();
       togglePromptLibrary(true);
@@ -394,6 +781,7 @@
       }
     });
 
+    resetOptimizerPanel();
     updateSendButton();
     messageInput.focus();
 


### PR DESCRIPTION
## Summary
- implement a heuristic prompt optimizer with optional OpenAI rewrites and expose it via POST /api/optimize_prompt on the boss API
- extend Luka’s interface with an optimizer panel, styling, and client-side logic that consumes the new endpoint
- ensure CORS responses admit POST requests for the new workflow

## Testing
- `node boss-api/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68dd898e14fc832980cf1bf00ad3d252