### PR TITLE
Extend smoke script to cover chat endpoints

### DIFF
--- a/.codex/GUARDRAILS.md
+++ b/.codex/GUARDRAILS.md
@@ -2,6 +2,7 @@
 - Resolver-only paths (no absolute paths, no symlinks)
 - Do NOT write under a/, c/, o/, s/
 - CORS required for API
+- Server-only keys must remain on the server (never expose to UI/client)
 - Path traversal guard required for file reads
 
 ## Tests to run

--- a/run/change_units/CU-2025-10-01.yml
+++ b/run/change_units/CU-2025-10-01.yml
@@ -25,3 +25,16 @@
     - curl_api_file: pending
   guardrail_status: pending
   followups: ["Re-run validations before commit"]
+- time: "2025-10-01T21:07:30+07:00"
+  change_id: CU-2025-10-01-smoke-api-chat
+  summary: "Extend smoke checks for chat endpoints and document guardrails"
+  files_touched:
+    - run/smoke_api_ui.sh
+    - .codex/GUARDRAILS.md
+    - run/change_units/CU-2025-10-01.yml
+    - run/daily_reports/REPORT_2025-10-01.md
+  tags: ["automation","documentation"]
+  tests_ran:
+    - smoke_api_ui: pending
+  guardrail_status: pending
+  followups: []

--- a/run/daily_reports/REPORT_2025-10-01.md
+++ b/run/daily_reports/REPORT_2025-10-01.md
@@ -1,0 +1,9 @@
+# Daily Report — 2025-10-01
+
+## Summary
+- Extended smoke script to cover chat + prompt optimization endpoints.
+- Updated guardrails to clarify server-only key handling.
+- Logged manifest entry for today's maintenance.
+
+## Tests
+- smoke_api_ui: pending

--- a/run/smoke_api_ui.sh
+++ b/run/smoke_api_ui.sh
@@ -17,6 +17,16 @@ test -f "$INBOX/hello.md" || echo "# hello boss" > "$INBOX/hello.md"
 echo "==> Check API file"
 curl -fsS "$API/api/file/inbox/hello.md" | head -n1
 
+echo "==> Check API optimize_prompt"
+curl -fsS -X POST "$API/api/optimize_prompt" \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"Summarize hello"}' | jq -r '.optimized // .prompt // .error'
+
+echo "==> Check API chat"
+curl -fsS -X POST "$API/api/chat" \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"ping"}' | jq -r '.summary // .error'
+
 echo "==> Check UI port availability"
 if lsof -ti :$UI_PORT >/dev/null 2>&1; then
   echo " - Port $UI_PORT is busy. Kill? (y/N)"


### PR DESCRIPTION
## Summary
- extend the smoke script to cover the optimize_prompt and chat APIs
- note that server-only keys must remain on the server in the guardrails doc
- append the manifest and add today’s daily report entry for the change

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd89a6076083299829e2e4d56c56cb