### PR TITLE
Standardize API port 4000 and document remote access

### DIFF
--- a/boss-ui/luka.html
+++ b/boss-ui/luka.html
@@ -313,6 +313,7 @@
       optimizeStatus.textContent = 'Optimizing…';
       try {
         const res = await fetch(`${API_BASE}/api/optimize_prompt`, {
+          credentials: 'include',
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
@@ -353,6 +354,7 @@
       optimizeStatus.textContent = 'Dispatching chat…';
       try {
         const res = await fetch(`${API_BASE}/api/chat`, {
+          credentials: 'include',
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -387,7 +389,9 @@
     async function refreshConnectors() {
       connectorsList.textContent = 'Loading…';
       try {
-        const res = await fetch(`${API_BASE}/api/connectors/status`);
+        const res = await fetch(`${API_BASE}/api/connectors/status`, {
+          credentials: 'include'
+        });
         if (!res.ok) throw new Error('Failed to load connectors');
         const data = await res.json();
         connectorsList.innerHTML = '';
@@ -422,7 +426,10 @@
 
     async function loadCapabilities() {
       try {
-        const res = await fetch(`${API_BASE}/api/capabilities`, { cache: 'no-store' });
+        const res = await fetch(`${API_BASE}/api/capabilities`, {
+          cache: 'no-store',
+          credentials: 'include'
+        });
         if (!res.ok) {
           throw new Error(`capabilities request failed (${res.status})`);
         }


### PR DESCRIPTION
## Summary
- expose a capabilities endpoint in boss-api and ensure the service defaults to port 4000
- update luka.html to auto-select the API base for Cloudflare domains and gate UI actions by server capabilities
- refresh smoke checks, add remote-access documentation, and extend task recipes/change logs for the new workflow

## Testing
- `bash .codex/preflight.sh`
- `bash g/tools/mapping_drift_guard.sh --validate`
- `bash run/smoke_api_ui.sh`


------
https://chatgpt.com/codex/tasks/task_e_68de372d33e483298a0b0d26b56d7cc4