### PR TITLE
Add post-merge sync helper script and recipe

### DIFF
--- a/.codex/TASK_RECIPES.md
+++ b/.codex/TASK_RECIPES.md
@@ -153,3 +153,20 @@ git add -A
 git commit -m "feat: <summary> (CHANGE_ID: CU-2025-10-01-boss-ui-api-v1) #boss-api #boss-ui #resolver #preflight"
 git push
 
+
+## Recipe: Post-merge sync in Cursor (pull → verify → smoke → report)
+
+Purpose: Sync local workspace after PR merge, re-verify, and log a daily report.
+
+### Quick commands
+```bash
+git stash push -m "pre-pull safety stash" || true
+git fetch origin && git checkout main && git pull --rebase origin main
+export HOST=127.0.0.1 PORT=4000
+bash .codex/preflight.sh
+bash g/tools/mapping_drift_guard.sh --validate
+bash run/smoke_api_ui.sh
+mkdir -p run/daily_reports && echo "- $(date +%F) Post-merge sync OK" >> run/daily_reports/REPORT_$(date +%F).md
+git add run/daily_reports/REPORT_$(date +%F).md && git commit -m "chore(report): post-merge sync" || true
+git push origin main
+```

--- a/run/post_merge_sync.sh
+++ b/run/post_merge_sync.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "== Post-merge sync =="
+branch="$(git rev-parse --abbrev-ref HEAD)"
+[ "$branch" = "main" ] || git checkout main
+git fetch origin
+git pull --rebase origin main || true
+
+echo "== Preflight & mapping =="
+bash .codex/preflight.sh
+bash g/tools/mapping_drift_guard.sh --validate
+
+echo "== Smoke API/UI =="
+export HOST=${HOST:-127.0.0.1}
+export PORT=${PORT:-4000}
+bash run/smoke_api_ui.sh || true
+
+echo "== Daily report =="
+mkdir -p run/daily_reports
+echo "- $(date +%F) Post-merge sync run on $branch" >> run/daily_reports/REPORT_$(date +%F).md
+git add run/daily_reports/REPORT_$(date +%F).md || true
+git commit -m "chore(report): post-merge sync run" || true
+echo "Done."


### PR DESCRIPTION
## Summary
- add a reusable post-merge sync helper script that runs validation, smoke tests, and reporting
- document the post-merge sync workflow in the task recipes guide for quick reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de3be832e08329a2abd95271a1e05e