### PR TITLE
Add snapshot and run automation endpoints

### DIFF
--- a/run/change_units/CU-2025-10-02.yml
+++ b/run/change_units/CU-2025-10-02.yml
@@ -25,3 +25,15 @@
   tests_ran: [preflight:OK, drift_guard:OK, smoke_api_ui:OK]
   guardrail_status: OK
   followups: []
+- time: "2025-10-02T12:00:00Z"
+  change_id: CU-2025-10-02-snapshot-run-endpoints
+  summary: "Add consolidated snapshot endpoint, allowlisted run executor, and extend smoke coverage."
+  files_touched:
+    - boss-api/server.cjs
+    - run/smoke_api_ui.sh
+    - run/change_units/CU-2025-10-02.yml
+    - run/daily_reports/REPORT_2025-10-02.md
+  tags: [boss-api, smoke, preflight]
+  tests_ran: []
+  guardrail_status: pending
+  followups: []

--- a/run/daily_reports/REPORT_2025-10-02.md
+++ b/run/daily_reports/REPORT_2025-10-02.md
@@ -1,3 +1,4 @@
 - Added smoke coverage for upload endpoint and connectors readiness.
 - 2025-10-02 CLC re-check passed: capabilities + smoke
 - Standardized API on 4000, UI domain auto-switch, smoke updated, remote access guide added. (CU-2025-10-02-ports-4000-remote-access)
+- Added API snapshot endpoint, local run executor, and smoke validation for both. (CU-2025-10-02-snapshot-run-endpoints)


### PR DESCRIPTION
## Summary
- add a consolidated /api/snapshot endpoint that reads auto_context artifacts with safe fallbacks
- add a local-only /api/run executor with an explicit allowlist and logging
- extend smoke coverage and logs to exercise the new endpoints

## Testing
- HOST=127.0.0.1 PORT=4001 node boss-api/server.cjs
- curl -s http://127.0.0.1:4001/api/snapshot | jq .
- curl -s -X POST http://127.0.0.1:4001/api/run -H 'Content-Type: application/json' -d '{"cmd":"preflight"}'


------
https://chatgpt.com/codex/tasks/task_e_68de98eab47c8329ba2a7a53a0dd9c0c