### PR TITLE
Add local inference engines and detection to boss-api

### DIFF
--- a/boss-api/data/.gitignore
+++ b/boss-api/data/.gitignore
@@ -1,0 +1,4 @@
+# Local databases generated at runtime
+*.sqlite3
+*.sqlite
+*.db

--- a/g/tools/embed_text.py
+++ b/g/tools/embed_text.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Utility script to generate text embeddings via BGE-M3 or a deterministic fallback."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import hashlib
+from typing import List
+
+MODEL_NAME = os.environ.get("EMBED_MODEL", "BAAI/bge-m3")
+
+def load_model():
+    try:
+        from sentence_transformers import SentenceTransformer  # type: ignore
+        model = SentenceTransformer(MODEL_NAME)
+        return model, "bge-m3"
+    except Exception:
+        return None, "hash"
+
+def hashed_embedding(text: str, dims: int = 384) -> List[float]:
+    tokens = [token for token in text.lower().split() if token]
+    if not tokens:
+        return [0.0] * dims
+    vector = [0.0] * dims
+    for token in tokens:
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        for idx in range(0, len(digest), 4):
+            slot = int.from_bytes(digest[idx:idx + 4], "little") % dims
+            sign = -1.0 if digest[idx] % 2 else 1.0
+            vector[slot] += sign
+    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
+    return [value / norm for value in vector]
+
+def compute_embedding(text: str):
+    model, backend = load_model()
+    if model is None:
+        return hashed_embedding(text), backend
+    try:
+        embedding = model.encode([text], normalize_embeddings=True)[0]
+        return embedding.tolist(), backend
+    except Exception:
+        return hashed_embedding(text), "hash"
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate embeddings using a local model.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON output (default).")
+    parser.add_argument("--text", type=str, help="Text to embed. Reads stdin if omitted.", default=None)
+    parser.add_argument("--ping", action="store_true", help="Health check mode")
+    return parser.parse_args()
+
+def main() -> int:
+    args = parse_args()
+    if args.ping:
+        payload = {"ok": True, "backend": MODEL_NAME}
+        sys.stdout.write(json.dumps(payload))
+        return 0
+
+    text = args.text if args.text is not None else sys.stdin.read()
+    if not text or not text.strip():
+        sys.stderr.write("No text provided for embedding.\n")
+        return 2
+
+    embedding, backend = compute_embedding(text.strip())
+    payload = {"embedding": embedding, "backend": backend, "model": MODEL_NAME}
+    sys.stdout.write(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/g/tools/ocr_typhoon.py
+++ b/g/tools/ocr_typhoon.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Thin wrapper for local OCR using Typhoon-compatible tooling or fallbacks."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run OCR on an image file using local tooling.")
+    parser.add_argument("image", nargs="?", help="Image file to OCR")
+    parser.add_argument("--format", choices=["json", "markdown"], default="json")
+    parser.add_argument("--ping", action="store_true", help="Health check mode")
+    return parser.parse_args()
+
+
+def try_pytesseract(image_path: Path) -> Optional[Tuple[str, str]]:
+    try:
+        from PIL import Image  # type: ignore
+        import pytesseract  # type: ignore
+    except Exception:
+        return None
+
+    try:
+        image = Image.open(str(image_path))
+    except Exception:
+        return None
+
+    try:
+        text = pytesseract.image_to_string(image)
+    except Exception:
+        return None
+    finally:
+        try:
+            image.close()
+        except Exception:
+            pass
+    return text.strip(), "pytesseract"
+
+
+def try_text_file(image_path: Path) -> Optional[Tuple[str, str]]:
+    try:
+        data = image_path.read_text(encoding="utf-8")
+        return data.strip(), "text"
+    except Exception:
+        return None
+
+
+def run_ocr(image_path: Path) -> Tuple[str, str]:
+    for candidate in (try_pytesseract, try_text_file):
+        result = candidate(image_path)
+        if result and result[0]:
+            return result
+    return ("", "unavailable")
+
+
+def emit_markdown(text: str, backend: str, image_path: Path) -> str:
+    summary = text.splitlines()
+    snippet = "\n".join(summary[:10])
+    return "\n".join(
+        [
+            "## OCR Result",
+            "",
+            f"**Backend**: {backend}",
+            f"**Source**: `{image_path}`",
+            "",
+            "```text",
+            snippet,
+            "```",
+        ]
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    if args.ping:
+        payload = {"ok": True, "backend": "typhoon-stub"}
+        sys.stdout.write(json.dumps(payload))
+        return 0
+
+    if not args.image:
+        sys.stderr.write("An image path is required.\n")
+        return 2
+
+    image_path = Path(args.image).expanduser().resolve()
+    if not image_path.exists():
+        payload = {"ok": False, "error": "Image not found", "path": str(image_path)}
+        sys.stdout.write(json.dumps(payload))
+        return 0
+
+    text, backend = run_ocr(image_path)
+    payload = {
+        "ok": bool(text),
+        "backend": backend,
+        "text": text,
+        "path": str(image_path),
+    }
+
+    if args.format == "markdown":
+        payload["markdown"] = emit_markdown(text, backend, image_path)
+
+    sys.stdout.write(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add capability detection for local chat, RAG, SQL, and OCR backends and expose richer `/api/capabilities` metadata
- implement `/api/engines/*` endpoints that dispatch to local Ollama, sqlite RAG, sandboxed SQL, and OCR tooling with graceful fallbacks
- add helper Python scripts for embeddings and OCR plus runtime data ignore rules and automatic sample dataset seeding

## Testing
- node --check boss-api/server.cjs
- python3 g/tools/embed_text.py --ping
- python3 g/tools/ocr_typhoon.py --ping

------
https://chatgpt.com/codex/tasks/task_e_68dfb626b7308329a66130fa73ff46f8