### PR TITLE
Add Unified Gap Audit Contract v0 and quick-reference link

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -120,3 +120,5 @@ git push origin <branch>
 
 **Status:** ✅ Ready to resolve
 **Time to resolve:** ~5 minutes (automatic) or ~20 minutes (manual)
+
+- Unified Gap Audit Contract: `UNIFIED_GAP_AUDIT_CONTRACT_v0.md`

--- a/UNIFIED_GAP_AUDIT_CONTRACT_v0.md
+++ b/UNIFIED_GAP_AUDIT_CONTRACT_v0.md
@@ -1,0 +1,59 @@
+# Unified Gap Audit Contract v0
+
+This contract standardizes how to report gaps so each finding is isolated, source-scoped, and layer-safe.
+
+## Pre-Gap Gate (must pass before any gap is logged)
+
+1. **State source authority**
+   - Name the canonical source document/system of record.
+   - If multiple candidates exist, select one primary and mark alternates as references.
+
+2. **State layer**
+   - Declare exactly one layer for the next finding:
+     - `constitutional`
+     - `registry`
+     - `schema`
+     - `runtime`
+
+3. **One-gap-one-mismatch**
+   - Each gap entry must represent one mismatch only.
+   - If two mismatches are discovered, emit two entries.
+
+4. **Status mark is mandatory**
+   - Every gap entry must include exactly one status:
+     - `duplicate`
+     - `refute`
+     - `verify-needed`
+
+5. **No cross-layer mixing**
+   - A single gap entry cannot include evidence from multiple layers as the mismatch basis.
+   - Cross-layer implications are recorded as notes only, not as part of mismatch proof.
+
+6. **Ambiguity HOLD rule**
+   - If gap IDs or source references are ambiguous, stop and return:
+     - `HOLD: ambiguous gap id/source`
+   - Do not log a gap until ambiguity is resolved.
+
+## Gap Entry Template
+
+```yaml
+gap_id: <id or HOLD>
+source_authority: <canonical source>
+layer: <constitutional|registry|schema|runtime>
+mismatch: <single mismatch statement>
+status: <duplicate|refute|verify-needed>
+evidence:
+  - <specific citation/artifact>
+notes:
+  - <optional, non-mismatch context>
+```
+
+## HOLD Response Template
+
+```text
+HOLD: ambiguous gap id/source
+needed:
+  - canonical_source
+  - explicit_gap_id_or_target_scope
+  - declared_layer
+```


### PR DESCRIPTION
### Motivation
- Introduce a canonical, machine-friendly audit contract to standardize gap reports by requiring a declared source authority, a single layer, one-gap-one-mismatch entries, an explicit status (`duplicate`|`refute`|`verify-needed`), prohibition on cross-layer evidence mixing, and a mandatory HOLD when gap IDs or sources are ambiguous.

### Description
- Add `UNIFIED_GAP_AUDIT_CONTRACT_v0.md` with the pre-gap gate, gap entry YAML template, and HOLD response template, and add a pointer to that file in `QUICK_REFERENCE.md`; this is documentation-only and does not change runtime code.

### Testing
- Confirmed the new document and quick-reference addition by inspecting files with `nl -ba UNIFIED_GAP_AUDIT_CONTRACT_v0.md` and `nl -ba QUICK_REFERENCE.md | tail -n 20`, both showing the expected content and pointer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e40b25c94c8329a834bc8637251aab)